### PR TITLE
Restyle

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -53,7 +53,6 @@
               "src/assets"
             ],
             "styles": [
-              "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.scss",
               "src/app/common-ui-elements/input-styles.scss"
             ],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -32,7 +32,7 @@
       [mode]="uiService.isScreenSmall() ? 'over' : 'side'"
     >
       <div style="width: 100%; text-align: center"></div>
-      <h4 *ngIf="remult.authenticated()">
+      <h4 *ngIf="remult.authenticated()" style="margin: 20px 6px;">
         {{ terms.hello }} {{ remult.user!.name }}
       </h4>
       <mat-nav-list role="list">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,21 +1,5 @@
-$dark-blue: #0e1f36;
-$dark-gray: #1f2636;
-$gold: #d39637;
-
-.mat-toolbar.mat-primary {
-  background: $dark-gray; 
-}
-
-.mat-flat-button.mat-primary, .mat-raised-button.mat-primary, .mat-fab.mat-primary, .mat-mini-fab.mat-primary {
-  background-color: $gold;  
-}
-
 .active-route {
   background-color: #f2f2f2;
-}
-
-.mat-drawer-container {
-  background: $dark-blue;
 }
 
 .app-sidenav-container {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -10,6 +10,7 @@
   //   min-height:100%;
   border: 1px solid rgba(0, 0, 0, 0.5);
 }
+
 .mat-toolbar {
   display: flex;
 }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -11,7 +11,7 @@ $gold: #d39637;
 }
 
 .active-route {
-  background-color: #f2f2f2;;
+  background-color: #f2f2f2;
 }
 
 .mat-drawer-container {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,21 @@
+$dark-blue: #0e1f36;
+$dark-gray: #1f2636;
+$gold: #d39637;
+
+.mat-toolbar.mat-primary {
+  background: $dark-gray; 
+}
+
+.mat-flat-button.mat-primary, .mat-raised-button.mat-primary, .mat-fab.mat-primary, .mat-mini-fab.mat-primary {
+  background-color: $gold;  
+}
+
 .active-route {
-  background-color: #f2f2f2;
+  background-color: #f2f2f2;;
+}
+
+.mat-drawer-container {
+  background: $dark-blue;
 }
 
 .app-sidenav-container {

--- a/src/app/common-ui-elements/src/angular/date-grid-2/data-grid2.component.scss
+++ b/src/app/common-ui-elements/src/angular/date-grid-2/data-grid2.component.scss
@@ -60,13 +60,13 @@
 
 .dataGridHeaderCell,
 .dataGridDataCell {
-  padding: 4px;
+  padding: 14px 8px;
 }
 
 .dataGridHeaderCell {}
 
 .dataGridDataCell {
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid #efefef;
 }
 
 .data-grid-row-more-buttons {
@@ -95,7 +95,7 @@
 }
 
 .dataGridFooterArea {
-  border: 1px solid #e0e0e0;
+  border: 1px solid #efefef;
 }
 
 .filterDialog {

--- a/src/app/common-ui-elements/src/angular/date-grid-2/data-grid2.component.scss
+++ b/src/app/common-ui-elements/src/angular/date-grid-2/data-grid2.component.scss
@@ -11,6 +11,7 @@
   overflow: auto;
   border: 1px solid #e0e0e0;
   height: 100%;
+  background: white;
 }
 
 .dataGridBodyArea {}

--- a/src/app/common/card-in-middle/card-in-middle.component.html
+++ b/src/app/common/card-in-middle/card-in-middle.component.html
@@ -1,5 +1,5 @@
-<div style="display: flex; justify-content: center">
-  <mat-card style="min-width: 300px; max-width: 400px" class="card-width">
+<div style="display: flex; justify-content: center;">
+  <mat-card style="min-width: 300px; max-width: 400px; margin-top: 20px;" class="card-width">
     <ng-content></ng-content>
   </mat-card>
 </div>

--- a/src/app/common/card-in-middle/card-in-middle.component.ts
+++ b/src/app/common/card-in-middle/card-in-middle.component.ts
@@ -1,15 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { BackgroundColorService } from '../../services/background-color.service';
 
 @Component({
   selector: 'app-card-in-middle',
   templateUrl: './card-in-middle.component.html',
   styleUrls: ['./card-in-middle.component.scss']
 })
-export class CardInMiddleComponent implements OnInit {
+export class CardInMiddleComponent implements OnInit, OnDestroy {
 
-  constructor() { }
+  constructor(private globalStyleService: BackgroundColorService) {}
 
-  ngOnInit(): void {
+  ngOnInit() {
+    this.globalStyleService.addGlobalStyle();
+  }
+
+  ngOnDestroy() {
+    this.globalStyleService.removeGlobalStyle();
   }
 
 }

--- a/src/app/process-requests/process-requests.component.html
+++ b/src/app/process-requests/process-requests.component.html
@@ -1,6 +1,6 @@
 <div>
-  <form>
-    <div *ngFor="let option of options">
+  <form style="margin: 20px 0; display: flex;">
+    <div *ngFor="let option of options" style="margin: 0 8px 5px;">
       <input
         type="radio"
         [value]="option"

--- a/src/app/services/background-color.service.ts
+++ b/src/app/services/background-color.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, RendererFactory2, Renderer2 } from '@angular/core';
+
+const darkBgClassName = 'dark-bg';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BackgroundColorService {
+  private renderer: Renderer2;
+
+  constructor(rendererFactory: RendererFactory2) {
+    this.renderer = rendererFactory.createRenderer(null, null);
+  }
+
+  addGlobalStyle() {
+    this.renderer.addClass(document.body, darkBgClassName);
+  }
+
+  removeGlobalStyle() {
+    this.renderer.removeClass(document.body, darkBgClassName);
+  }
+}

--- a/src/app/volunteer-request/volunteer-request.component.html
+++ b/src/app/volunteer-request/volunteer-request.component.html
@@ -9,6 +9,7 @@
     selectable
     multiple
     (click)="chipSelected($event)"
+    style="display: block; margin-bottom: 20px;"
   >
     <mat-chip
       *ngFor="let l of legalExpertise"

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,11 @@
+/**
+* Generated theme by Material Theme Generator
+* https://materialtheme.arcsine.dev
+* Fork at: https://materialtheme.arcsine.dev/?c=YHBhbGV0dGU$YHByaW1hcnk$YF48IzIxMjgzYSIsIj9lcjwjYmNiZmM0IiwiO2VyPCMxNDE4MjV$LCIlPmBePCNkMzk2MzciLCI~ZXI8I2YyZTBjMyIsIjtlcjwjYzI3OTIzfiwid2Fybj5gXjwjZmYwMDAwIiwiP2VyPCNmZmIzYjMiLCI7ZXI8I2ZmMDAwMH4sIj9UZXh0PCMwZTFmMzYiLCI~PTwjZjlmOWY5IiwiO1RleHQ8I2ZmZmZmZiIsIjs9PCMwZTFmMzZ$LCJmb250cz5bYEA8KC00IiwiZmFtaWx5PEVuY29kZSBTYW5zfixgQDwoLTMiLCJmYW1pbHk8RW5jb2RlIFNhbnN$LGBAPCgtMiIsImZhbWlseTxFbmNvZGUgU2Fuc34sYEA8KC0xIiwiZmFtaWx5PEVuY29kZSBTYW5zfixgQDxoZWFkbGluZSIsImZhbWlseTxFbmNvZGUgU2Fuc34sYEA8dGl0bGUiLCJmYW1pbHk8RW5jb2RlIFNhbnN$LGBAPHN1YiktMiIsImZhbWlseTxFbmNvZGUgU2Fuc34sYEA8c3ViKS0xIiwiZmFtaWx5PEVuY29kZSBTYW5zfixgQDxib2R5LTIiLCJmYW1pbHk8RW5jb2RlIFNhbnN$LGBAPGJvZHktMSIsImZhbWlseTxFbmNvZGUgU2Fuc34sYEA8YnV0dG9uIiwiZmFtaWx5PEVuY29kZSBTYW5zfixgQDxjYXB0aW9uIiwiZmFtaWx5PEVuY29kZSBTYW5zfixgQDxpbnB1dCIsImZhbWlseTxFbmNvZGUgU2FucyIsInNpemU$bnVsbH1dLCJpY29uczxSb3VuZGVkIiwiP25lc3M$dHJ1ZSwidmVyc2lvbj4xM30=
+*/
+
+@use '@angular/material' as mat;
+
 // this code makes the font size larger than the standard
 @import '~@angular/material/theming';
 
@@ -7,32 +15,257 @@
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
 @include mat-core();
-@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;700&display=swap');
 
-$custom-typography: mat-typography-config($font-family: 'Rubik,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;',
-    $display-4: mat-typography-level(112px, 112px, 300),
-    $display-3: mat-typography-level(56px, 56px, 400),
-    $display-2: mat-typography-level(45px, 48px, 400),
-    $display-1: mat-typography-level(34px, 40px, 400),
-    $headline: mat-typography-level(28px, 34px, 400),
-    $title: mat-typography-level(24px, 32px, 500),
-    $subheading-2: mat-typography-level(20px, 28px, 400),
-    $subheading-1: mat-typography-level(20px, 28px, 400),
-    $body-2: mat-typography-level(18px, 24px, 500),
-    $body-1: mat-typography-level(18px, 24px, 400),
-    $caption: mat-typography-level(18px, 24px, 400),
-    $button: mat-typography-level(18px, 16px, 500),
-    $input: mat-typography-level(18px, 1.125, 400));
-// Override typography CSS classes (e.g., mat-h1, mat-display-1, mat-typography, etc.).
-@include mat-base-typography($custom-typography);
+@import 'https://fonts.googleapis.com/icon?family=Material+Icons+Round';
+@import url('https://fonts.googleapis.com/css2?family=Encode+Sans:wght@300;400;500&display=swap');
 
-// Override typography for a specific Angular Material components.
-@include mat-checkbox-typography($custom-typography);
+$fontConfig: (
+  display-4: mat.define-typography-level(112px, 112px, 300, 'Encode Sans', -0.0134em),
+  display-3: mat.define-typography-level(56px, 56px, 400, 'Encode Sans', -0.0089em),
+  display-2: mat.define-typography-level(45px, 48px, 400, 'Encode Sans', 0.0000em),
+  display-1: mat.define-typography-level(34px, 40px, 400, 'Encode Sans', 0.0074em),
+  headline: mat.define-typography-level(24px, 32px, 400, 'Encode Sans', 0.0000em),
+  title: mat.define-typography-level(20px, 32px, 500, 'Encode Sans', 0.0075em),
+  subheading-2: mat.define-typography-level(16px, 28px, 400, 'Encode Sans', 0.0094em),
+  subheading-1: mat.define-typography-level(15px, 24px, 500, 'Encode Sans', 0.0067em),
+  body-2: mat.define-typography-level(14px, 24px, 500, 'Encode Sans', 0.0179em),
+  body-1: mat.define-typography-level(14px, 20px, 400, 'Encode Sans', 0.0179em),
+  button: mat.define-typography-level(14px, 14px, 500, 'Encode Sans', 0.0893em),
+  caption: mat.define-typography-level(12px, 20px, 400, 'Encode Sans', 0.0333em),
+  input: mat.define-typography-level(inherit, 1.125, 400, 'Encode Sans', 1.5px)
+);
 
-// Override typography for all Angular Material, including mat-base-typography and all components.
-@include angular-material-typography($custom-typography);
+// Foreground Elements
 
-/* You can add global styles to this file, and also import other style files */
+// Light Theme Text
+$dark-text: #0e1f36;
+$dark-primary-text: rgba($dark-text, 0.87);
+$dark-accent-text: rgba($dark-primary-text, 0.54);
+$dark-disabled-text: rgba($dark-primary-text, 0.38);
+$dark-dividers: rgba($dark-primary-text, 0.12);
+$dark-focused: rgba($dark-primary-text, 0.12);
+
+$mat-light-theme-foreground: (
+  base:              black,
+  divider:           $dark-dividers,
+  dividers:          $dark-dividers,
+  disabled:          $dark-disabled-text,
+  disabled-button:   rgba($dark-text, 0.26),
+  disabled-text:     $dark-disabled-text,
+  elevation:         black,
+  secondary-text:    $dark-accent-text,
+  hint-text:         $dark-disabled-text,
+  accent-text:       $dark-accent-text,
+  icon:              $dark-accent-text,
+  icons:             $dark-accent-text,
+  text:              $dark-primary-text,
+  slider-min:        $dark-primary-text,
+  slider-off:        rgba($dark-text, 0.26),
+  slider-off-active: $dark-disabled-text,
+);
+
+// Dark Theme text
+$light-text: #ffffff;
+$light-primary-text: $light-text;
+$light-accent-text: rgba($light-primary-text, 0.7);
+$light-disabled-text: rgba($light-primary-text, 0.5);
+$light-dividers: rgba($light-primary-text, 0.12);
+$light-focused: rgba($light-primary-text, 0.12);
+
+$mat-dark-theme-foreground: (
+  base:              $light-text,
+  divider:           $light-dividers,
+  dividers:          $light-dividers,
+  disabled:          $light-disabled-text,
+  disabled-button:   rgba($light-text, 0.3),
+  disabled-text:     $light-disabled-text,
+  elevation:         black,
+  hint-text:         $light-disabled-text,
+  secondary-text:    $light-accent-text,
+  accent-text:       $light-accent-text,
+  icon:              $light-text,
+  icons:             $light-text,
+  text:              $light-text,
+  slider-min:        $light-text,
+  slider-off:        rgba($light-text, 0.3),
+  slider-off-active: rgba($light-text, 0.3),
+);
+
+// Background config
+// Light bg
+$light-background:    #f9f9f9;
+$light-bg-darker-5:   darken($light-background, 5%);
+$light-bg-darker-10:  darken($light-background, 10%);
+$light-bg-darker-20:  darken($light-background, 20%);
+$light-bg-darker-30:  darken($light-background, 30%);
+$light-bg-lighter-5:  lighten($light-background, 5%);
+$dark-bg-tooltip:     lighten(#0e1f36, 20%);
+$dark-bg-alpha-4:     rgba(#0e1f36, 0.04);
+$dark-bg-alpha-12:    rgba(#0e1f36, 0.12);
+
+$mat-light-theme-background: (
+  background:               $light-background,
+  status-bar:               $light-bg-darker-20,
+  app-bar:                  $light-bg-darker-5,
+  hover:                    $dark-bg-alpha-4,
+  card:                     $light-bg-lighter-5,
+  dialog:                   $light-bg-lighter-5,
+  tooltip:                  $dark-bg-tooltip,
+  disabled-button:          $dark-bg-alpha-12,
+  raised-button:            $light-bg-lighter-5,
+  focused-button:           $dark-focused,
+  selected-button:          $light-bg-darker-20,
+  selected-disabled-button: $light-bg-darker-30,
+  disabled-button-toggle:   $light-bg-darker-10,
+  unselected-chip:          $light-bg-darker-10,
+  disabled-list-option:     $light-bg-darker-10,
+);
+
+// Dark bg
+$dark-background:     #0e1f36;
+$dark-bg-lighter-5:   lighten($dark-background, 5%);
+$dark-bg-lighter-10:  lighten($dark-background, 10%);
+$dark-bg-lighter-20:  lighten($dark-background, 20%);
+$dark-bg-lighter-30:  lighten($dark-background, 30%);
+$light-bg-alpha-4:    rgba(#f9f9f9, 0.04);
+$light-bg-alpha-12:   rgba(#f9f9f9, 0.12);
+
+// Background palette for dark themes.
+$mat-dark-theme-background: (
+  background:               $dark-background,
+  status-bar:               $dark-bg-lighter-20,
+  app-bar:                  $dark-bg-lighter-5,
+  hover:                    $light-bg-alpha-4,
+  card:                     $dark-bg-lighter-5,
+  dialog:                   $dark-bg-lighter-5,
+  tooltip:                  $dark-bg-lighter-20,
+  disabled-button:          $light-bg-alpha-12,
+  raised-button:            $dark-bg-lighter-5,
+  focused-button:           $light-focused,
+  selected-button:          $dark-bg-lighter-20,
+  selected-disabled-button: $dark-bg-lighter-30,
+  disabled-button-toggle:   $dark-bg-lighter-10,
+  unselected-chip:          $dark-bg-lighter-20,
+  disabled-list-option:     $dark-bg-lighter-10,
+);
+
+// Compute font config
+@include mat.core($fontConfig);
+
+// Theme Config
+
+body {
+  --primary-color: #21283a;
+  --primary-lighter-color: #bcbfc4;
+  --primary-darker-color: #141825;
+  --text-primary-color: #{$light-primary-text};
+  --text-primary-lighter-color: #{$dark-primary-text};
+  --text-primary-darker-color: #{$light-primary-text};
+}   
+$mat-primary: (
+  main: #21283a,
+  lighter: #bcbfc4,
+  darker: #141825,
+  200: #21283a, // For slide toggle,
+  contrast : (
+    main: $light-primary-text,
+    lighter: $dark-primary-text,
+    darker: $light-primary-text,
+  )
+);
+$theme-primary: mat.define-palette($mat-primary, main, lighter, darker);
+
+
+body {
+  --accent-color: #d39637;
+  --accent-lighter-color: #f2e0c3;
+  --accent-darker-color: #c27923;
+  --text-accent-color: #{$dark-primary-text};
+  --text-accent-lighter-color: #{$dark-primary-text};
+  --text-accent-darker-color: #{$dark-primary-text};
+}   
+$mat-accent: (
+  main: #d39637,
+  lighter: #f2e0c3,
+  darker: #c27923,
+  200: #d39637, // For slide toggle,
+  contrast : (
+    main: $dark-primary-text,
+    lighter: $dark-primary-text,
+    darker: $dark-primary-text,
+  )
+);
+$theme-accent: mat.define-palette($mat-accent, main, lighter, darker);
+
+
+body {
+  --warn-color: #ff0000;
+  --warn-lighter-color: #ffb3b3;
+  --warn-darker-color: #ff0000;
+  --text-warn-color: #{$light-primary-text};
+  --text-warn-lighter-color: #{$dark-primary-text};
+  --text-warn-darker-color: #{$light-primary-text};
+}   
+$mat-warn: (
+  main: #ff0000,
+  lighter: #ffb3b3,
+  darker: #ff0000,
+  200: #ff0000, // For slide toggle,
+  contrast : (
+    main: $light-primary-text,
+    lighter: $dark-primary-text,
+    darker: $light-primary-text,
+  )
+);
+$theme-warn: mat.define-palette($mat-warn, main, lighter, darker);
+;
+
+$theme: (
+  primary: $theme-primary,
+  accent: $theme-accent,
+  warn: $theme-warn,
+  is-dark: false,
+  foreground: $mat-light-theme-foreground,
+  background: $mat-light-theme-background,
+);
+$altTheme: (
+  primary: $theme-primary,
+  accent: $theme-accent,
+  warn: $theme-warn,
+  is-dark: true,
+  foreground: $mat-dark-theme-foreground,
+  background: $mat-dark-theme-background,
+);
+
+// Theme Init
+@include mat.all-component-themes($theme);
+
+.theme-alternate {
+  @include mat.all-component-themes($altTheme);
+}
+
+// Specific component overrides, pieces that are not in line with the general theming
+
+// Handle buttons appropriately, with respect to line-height
+.mat-raised-button, .mat-stroked-button, .mat-flat-button {
+  padding: 0 1.15em;
+  margin: 0 .65em;
+  min-width: 3em;
+  line-height: 36.4px
+}
+
+.mat-standard-chip {
+  padding: .5em .85em;
+  min-height: 2.5em;
+}
+
+.material-icons {
+  font-size: 24px;
+  font-family: 'Material Icons Round', 'Material Icons';  
+  .mat-badge-content {
+    font-family: 'Encode Sans';
+  }
+}
 
 // End of font size code
 
@@ -41,22 +274,17 @@ body {
   height: 100%;
 }
 
-body {
-  margin: 0;
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
-}
+// a {
+//   background-color: transparent;
+//   color: var(--primary-color);
+//   text-decoration: none;
+// }
 
-a {
-  background-color: transparent;
-  color: #337ab7;
-  text-decoration: none;
-}
-
-a:hover {
-  background-color: transparent;
-  color: #337ab7;
-  text-decoration: underline;
-}
+// a:hover {
+//   background-color: transparent;
+//   color: var(--primary-color);
+//   text-decoration: underline;
+// }
 
 .full-page {
   height: 100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -272,19 +272,25 @@ $altTheme: (
 html,
 body {
   height: 100%;
+  margin: 0;
+  padding: 0;
 }
 
-// a {
-//   background-color: transparent;
-//   color: var(--primary-color);
-//   text-decoration: none;
-// }
+a {
+  background-color: transparent;
+  color: var(--primary-color);
+  text-decoration: none;
+}
 
-// a:hover {
-//   background-color: transparent;
-//   color: var(--primary-color);
-//   text-decoration: underline;
-// }
+a:hover {
+  background-color: transparent;
+  color: var(--primary-color);
+  text-decoration: underline;
+}
+
+.mat-flat-button.mat-primary, .mat-raised-button.mat-primary, .mat-fab.mat-primary, .mat-mini-fab.mat-primary {
+  background-color: var(--accent-color);  
+}
 
 .full-page {
   height: 100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -320,8 +320,8 @@ a:hover {
 .table,
 th,
 td {
-  border: 1px solid #ddd;
-  padding: 10px 10px;
+  border: 1px solid #efefef;
+  padding: 16px 10px;
 }
 
 th {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -292,6 +292,10 @@ a:hover {
   background-color: var(--accent-color);  
 }
 
+.dark-bg .app-sidenav-container {
+  background: #0e1f36;
+}
+
 .full-page {
   height: 100%;
   display: flex;


### PR DESCRIPTION
- Turned off `indigo-pink` pre-built theme, and added custom theme with brand colors
- Swapped Roboto font for Encode Sans
- Created service to turn on dark blue background only for `card-in-middle` pages
- Changed data grid style to have more muted borders and larger cell sizes
- other misc. style tweaks

<img width="1437" alt="Screenshot 2023-12-17 at 6 28 17 PM" src="https://github.com/noam-honig/law-q/assets/157232/2dc29f18-0201-4787-bca4-74835b0caa10">
<img width="1437" alt="Screenshot 2023-12-17 at 6 28 35 PM" src="https://github.com/noam-honig/law-q/assets/157232/fede741e-34ac-40b6-840a-f4d96efa6e74">
<img width="1434" alt="Screenshot 2023-12-17 at 6 28 27 PM" src="https://github.com/noam-honig/law-q/assets/157232/3e1c83f7-8061-4618-9b8d-2a8a2c12d39d">
